### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/helm-lint.yaml
+++ b/.github/workflows/helm-lint.yaml
@@ -4,6 +4,9 @@ on:
   pull_request:
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   lint-test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/SpechtLabs/helm-charts/security/code-scanning/2](https://github.com/SpechtLabs/helm-charts/security/code-scanning/2)

To fix the issue, we need to add a `permissions` block to the workflow. This block should specify the minimal permissions required for the workflow to function correctly. Based on the actions used in the workflow, the following permissions are likely sufficient:
- `contents: read` for accessing repository contents.
- Additional permissions can be added if specific actions require them, but none of the actions in the workflow appear to need write permissions.

The `permissions` block should be added at the root level of the workflow to apply to all jobs, as there is no indication that different jobs require different permissions.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
