### PR TITLE
chore: sync renovate config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,32 +1,52 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "config:recommended"
+    "config:recommended",
+    ":semanticCommits"
   ],
-  "packageRules": [
-    {
-      "description": "Automatically merge minor and patch-level updates",
-      "matchUpdateTypes": [
-        "patch",
-        "bump",
-        "minor"
-      ],
-      "automerge": true,
-      "automergeType": "branch"
-    },
-    {
-      "matchUpdateTypes": ["major"],
-      "automerge": false,
-      "labels": ["update/major"],
-      "assignees": ["cedi"]
-    }
+  "timezone": "Europe/Berlin",
+  "dependencyDashboard": true,
+  "dependencyDashboardTitle": "Dependency Dashboard",
+  "prHourlyLimit": 2,
+  "prConcurrentLimit": 8,
+  "rebaseWhen": "behind-base-branch",
+  "rangeStrategy": "bump",
+  "semanticCommitType": "chore",
+  "semanticCommitScope": "deps",
+  "labels": [
+    "dependencies"
   ],
+  "lockFileMaintenance": {
+    "enabled": true,
+    "schedule": [
+      "before 6am on monday"
+    ],
+    "automerge": true
+  },
   "customManagers": [
     {
       "customType": "regex",
+      "description": "Track the Go toolchain version pinned in .mise.toml.",
+      "managerFilePatterns": [
+        "/(^|/)\\.mise\\.toml$/"
+      ],
+      "matchStrings": [
+        "(?:^|\\n)go\\s*=\\s*\"(?<currentValue>\\d+\\.\\d+(?:\\.\\d+)?)\""
+      ],
+      "depNameTemplate": "go",
+      "packageNameTemplate": "go",
+      "datasourceTemplate": "golang-version",
+      "versioningTemplate": "semver"
+    },
+    {
+      "customType": "regex",
       "description": "Track SpechtLabs/StaticPages releases as the static-pages chart appVersion",
-      "managerFilePatterns": ["/^charts/static-pages/Chart\\.yaml$/"],
-      "matchStrings": ["appVersion:\\s*\"?(?<currentValue>[^\"\\s]+)\"?"],
+      "managerFilePatterns": [
+        "/^charts/static-pages/Chart\\.yaml$/"
+      ],
+      "matchStrings": [
+        "appVersion:\\s*\"?(?<currentValue>[^\"\\s]+)\"?"
+      ],
       "depNameTemplate": "SpechtLabs/StaticPages",
       "datasourceTemplate": "github-releases",
       "versioningTemplate": "semver"
@@ -34,18 +54,104 @@
     {
       "customType": "regex",
       "description": "Track SpechtLabs/tka releases as the tka chart appVersion",
-      "managerFilePatterns": ["/^charts/tka/Chart\\.yaml$/"],
-      "matchStrings": ["appVersion:\\s*\"?(?<currentValue>[^\"\\s]+)\"?"],
+      "managerFilePatterns": [
+        "/^charts/tka/Chart\\.yaml$/"
+      ],
+      "matchStrings": [
+        "appVersion:\\s*\"?(?<currentValue>[^\"\\s]+)\"?"
+      ],
       "depNameTemplate": "SpechtLabs/tka",
       "datasourceTemplate": "github-releases",
       "versioningTemplate": "semver"
     }
   ],
+  "packageRules": [
+    {
+      "description": "Automerge digest, pin, patch, and minor updates once CI passes.",
+      "matchUpdateTypes": [
+        "digest",
+        "pin",
+        "pinDigest",
+        "patch",
+        "minor"
+      ],
+      "automerge": true,
+      "automergeType": "pr",
+      "platformAutomerge": true
+    },
+    {
+      "description": "Keep major updates explicit.",
+      "matchUpdateTypes": [
+        "major"
+      ],
+      "automerge": false,
+      "dependencyDashboardApproval": true
+    },
+    {
+      "description": "Group GitHub Actions updates together.",
+      "matchManagers": [
+        "github-actions"
+      ],
+      "groupName": "GitHub Actions",
+      "groupSlug": "github-actions",
+      "automerge": true,
+      "automergeType": "pr",
+      "platformAutomerge": true,
+      "dependencyDashboardApproval": false
+    },
+    {
+      "description": "Do not manage npm as a separate mise tool; Node provides npm.",
+      "matchFileNames": [
+        ".mise.toml"
+      ],
+      "matchDepNames": [
+        "npm"
+      ],
+      "enabled": false
+    },
+    {
+      "description": "Group Go module updates together.",
+      "matchManagers": [
+        "gomod"
+      ],
+      "groupName": "Go modules",
+      "groupSlug": "go-modules"
+    },
+    {
+      "description": "Update .mise.toml and go.mod Go versions together.",
+      "matchDatasources": [
+        "golang-version"
+      ],
+      "matchDepNames": [
+        "go"
+      ],
+      "groupName": "Go toolchain",
+      "groupSlug": "go-toolchain",
+      "rangeStrategy": "bump",
+      "automerge": true,
+      "automergeType": "pr",
+      "platformAutomerge": true,
+      "dependencyDashboardApproval": false
+    },
+    {
+      "description": "Group docs site dependencies together.",
+      "matchFileNames": [
+        "docs/package.json",
+        "docs/bun.lock"
+      ],
+      "groupName": "docs dependencies",
+      "groupSlug": "docs-dependencies"
+    }
+  ],
   "bumpVersions": [
     {
       "name": "Bump the chart version whenever its appVersion (or any dependency) changes",
-      "filePatterns": ["{{packageFileDir}}/Chart.yaml"],
-      "matchStrings": ["(?m)^version:\\s+\"?(?<version>[^\"\\s]+)\"?"],
+      "filePatterns": [
+        "{{packageFileDir}}/Chart.yaml"
+      ],
+      "matchStrings": [
+        "(?m)^version:\\s+\"?(?<version>[^\"\\s]+)\"?"
+      ],
       "bumpType": "patch"
     }
   ]


### PR DESCRIPTION
## Summary
- port the Renovate baseline from kush
- enable semantic dependency commits, dependency dashboard, PR concurrency limits, lockfile maintenance, grouped updates, and dashboard approval for major updates
- preserve existing repo-specific Renovate behavior where present

## Validation
- Parsed all updated renovate.json files with Ruby JSON parser.

Notes:
- helm-charts keeps its chart appVersion custom managers and chart version bumping.
- rpi_exporter keeps includeForks enabled.